### PR TITLE
Fixed TagsEditTest/TagManagerActivity 

### DIFF
--- a/Team1TEAppTest/src/ca/ualberta/cs/team1travelexpenseapp/test/TagsEditTest.java
+++ b/Team1TEAppTest/src/ca/ualberta/cs/team1travelexpenseapp/test/TagsEditTest.java
@@ -1,11 +1,12 @@
 package ca.ualberta.cs.team1travelexpenseapp.test;
 
 import ca.ualberta.cs.team1travelexpenseapp.Claim;
-import ca.ualberta.cs.team1travelexpenseapp.ClaimsListController;
+import ca.ualberta.cs.team1travelexpenseapp.Tag;
 import ca.ualberta.cs.team1travelexpenseapp.TagListController;
-import ca.ualberta.cs.team1travelexpenseapp.TagsListController;
+import ca.ualberta.cs.team1travelexpenseapp.TagManagerActivity;
 import android.app.Activity;
 import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.content.Intent;
 import android.test.ActivityInstrumentationTestCase2;
 import android.view.View;
@@ -15,12 +16,12 @@ import android.widget.ListView;
 import android.widget.TextView;
 import junit.framework.TestCase;
 
-public class TagsEditTest extends ActivityInstrumentationTestCase2<EditTagActivity> {
-	Activity activity;
+public class TagsEditTest extends ActivityInstrumentationTestCase2<TagManagerActivity> {
+	TagManagerActivity activity;
 	ListView tagListView;
 	
-	public ClaimantClaimsListTest() {
-		super(EditTagActivity.class);
+	public TagsEditTest() {
+		super(TagManagerActivity.class);
 	}
 	
 	protected void setUp() throws Exception {
@@ -35,7 +36,7 @@ public class TagsEditTest extends ActivityInstrumentationTestCase2<EditTagActivi
 	
 	//US03.02.01: As a claimant, I want to manage my personal use of tags by listing 
 	//the available tags, adding a tag, renaming a tag, and deleting a tag.
-	public testTagList{
+	public void testTagList(){
 		String[] strings={"good","great","excellent"};
 		Tag tag1=new Tag(strings[0]);
 		Tag tag2=new Tag(strings[1]);
@@ -46,21 +47,24 @@ public class TagsEditTest extends ActivityInstrumentationTestCase2<EditTagActivi
 		TagListController.addTag(tag3);
 		
 		assertTrue("tags list on screen does not reflect added tags",checkTags(strings));
+		
+		ListView tagsListView=(ListView) activity.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagsList);
+		
 		//get tag list item at position 1
-		final View item=claimListView.getAdapter().getView(1, null, null);
+		final View item=tagsListView.getAdapter().getView(1, null, null);
 		activity.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				// click button, should produce dialog to choose edit or delete claim
-				item.performClick();
-				AlertDialog dialog=activity.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagDialog);
+				item.performLongClick();
+				AlertDialog dialog=activity.editTagDialog;
 				
 				//enter new name for the tag into tag name box in dialog
-				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagText);
+				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.simpleEditText);
 				tagName.setText("fantastic");
 				
 				//press the setName button in the dialog
-				Button setTagButton=(Button)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.setTagButton);
+				Button setTagButton=(Button)dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE);
 				setTagButton.performClick();
 				
 			}
@@ -74,44 +78,44 @@ public class TagsEditTest extends ActivityInstrumentationTestCase2<EditTagActivi
 			@Override
 			public void run() {
 				// click button, should produce dialog to choose edit or delete claim
-				item.performClick();
-				AlertDialog dialog=activity.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagDialog);
+				item.performLongClick();
+				AlertDialog dialog=activity.editTagDialog;
 				
 				//enter new name for the tag into tag name box in dialog
-				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagText);
+				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.simpleEditText);
 				tagName.setText("fantastic");
 				
 				//press the deleteTag button in the dialog
-				Button setTagButton=(Button)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.setTagButton);
-				setTagButton.performClick();
+				Button deleteTagButton=(Button) dialog.getButton(android.content.DialogInterface.BUTTON_NEGATIVE);
+				deleteTagButton.performClick();
 			}
 		});
 		
 		//the tags in the TagsListController should now match this update to the string array:
 		String[] strings2={"good","excellent"};
-		assertTrue("tags list on screen does not reflect deleted tag",checkTags(newStrings));
+		assertTrue("tags list on screen does not reflect deleted tag",checkTags(strings2));
 		
-		Button addTagButton=activity.findViewById(ca.ualberta.ca.team1travelexpenseapp.R.id.addTagButton);
+		final Button addTagButton=(Button) activity.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.addTagButton);
 		activity.runOnUiThread(new Runnable() {
 			@Override
 			public void run() {
 				// click button, should produce dialog to enter name of new tag
 				addTagButton.performClick();
-				AlertDialog dialog=activity.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.addTagDialog);
+				AlertDialog dialog=activity.newTagDialog;
 				
 				//enter new name for the tag into tag name box in dialog
-				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.tagText);
+				EditText tagName=(EditText)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.simpleEditText);
 				tagName.setText("fantastic");
 				
 				//press the setTag button in the dialog
-				Button addTagButton=(Button)dialog.findViewById(ca.ualberta.cs.team1travelexpenseapp.R.id.setTagButton);
+				Button setTagButton=(Button)dialog.getButton(android.content.DialogInterface.BUTTON_POSITIVE);
 				setTagButton.performClick();
 			}
 		});
 		
 		//the tags in the TagsListController should now match this update to the string array:
 		String[] strings3={"good","excellent","fantastic"};
-		assertTrue("tags list on screen does not reflect deleted tag",checkTags(strings2));
+		assertTrue("tags list on screen does not reflect deleted tag",checkTags(strings3));
 	}
 	
 	//this function checks if the info in the tagListView match the given string array

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagManagerActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagManagerActivity.java
@@ -21,6 +21,8 @@ import android.widget.AdapterView.OnItemClickListener;
 
 public class TagManagerActivity extends Activity {
 	private TagList tagList;
+	public AlertDialog newTagDialog;
+	public AlertDialog editTagDialog;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -50,31 +52,59 @@ public class TagManagerActivity extends Activity {
 			public boolean onItemLongClick(AdapterView<?> parent, View view,int index,
 					long id){
 						 final Tag tag= (Tag) tagsAdapter.getItem(index);
-						 AlertDialog.Builder editTagDialog = new AlertDialog.Builder(TagManagerActivity.this);
-							
-						 final EditText nameField = new EditText(TagManagerActivity.this);
-						 editTagDialog.setView(nameField);
-						 editTagDialog.setPositiveButton("save", new DialogInterface.OnClickListener() {
+						 
+						//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html
+						 AlertDialog.Builder editTagDialogBuilder = new AlertDialog.Builder(TagManagerActivity.this);
+						
+						 editTagDialogBuilder.setView(getLayoutInflater().inflate(R.layout.simple_edit_text, null));
+						 editTagDialogBuilder.setPositiveButton("save", new DialogInterface.OnClickListener() {
 					           public void onClick(DialogInterface dialog, int id) {
+					        	   EditText nameField=((EditText) ((AlertDialog) dialog).findViewById(R.id.simpleEditText));
 					               String name=nameField.getText().toString();
 					               TagListController.updateTag(tag, name);;
 					           }
 					       });
-						editTagDialog.setNegativeButton("delete", new DialogInterface.OnClickListener() {
+						editTagDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 					           public void onClick(DialogInterface dialog, int id) {
 					               TagListController.removeTag(tag);
 					           }
 					       });
-						editTagDialog.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
+						editTagDialogBuilder.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
 					           public void onClick(DialogInterface dialog, int id) {
 					               //Do nothing
 					           }
 					       });
-						editTagDialog.setTitle("New Tag Name:");
+						editTagDialogBuilder.setTitle("New Tag Name:");
+						editTagDialog=editTagDialogBuilder.create();
 						editTagDialog.show();
+						EditText nameField=((EditText) editTagDialog.findViewById(R.id.simpleEditText));
+						nameField.setText(tag.toString());
 						return true;//not too sure on return value look into this
 					}
 		});
+		
+		//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html
+		AlertDialog.Builder newTagDialogBuilder = new AlertDialog.Builder(this);
+		
+		newTagDialogBuilder.setView(getLayoutInflater().inflate(R.layout.simple_edit_text, null));
+		
+		newTagDialogBuilder.setPositiveButton("save", new DialogInterface.OnClickListener() {
+	           public void onClick(DialogInterface dialog, int id) {
+	               EditText nameField=((EditText) ((AlertDialog) dialog).findViewById(R.id.simpleEditText));
+	               String name=nameField.getText().toString();
+	               TagListController.addTag(new Tag(name));
+	           }
+	       });
+		newTagDialogBuilder.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
+	           public void onClick(DialogInterface dialog, int id) {
+	               //Do nothing
+	           }
+	       });
+		newTagDialogBuilder.setTitle("New Tag Name:");
+		newTagDialog=newTagDialogBuilder.create();
+		
+		
+		
 	}
 
 	@Override
@@ -97,25 +127,8 @@ public class TagManagerActivity extends Activity {
 	}
 	
 	public void onAddTagClick(View v){
-		
-		//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html
-		AlertDialog.Builder newTagDialog = new AlertDialog.Builder(this);
-		
-		final EditText nameField = new EditText(this);
-		newTagDialog.setView(nameField);
-		
-		newTagDialog.setPositiveButton("save", new DialogInterface.OnClickListener() {
-	           public void onClick(DialogInterface dialog, int id) {
-	               String name=nameField.getText().toString();
-	               TagListController.addTag(new Tag(name));
-	           }
-	       });
-		newTagDialog.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
-	           public void onClick(DialogInterface dialog, int id) {
-	               //Do nothing
-	           }
-	       });
-		newTagDialog.setTitle("New Tag Name:");
 		newTagDialog.show();
+		EditText nameField=(EditText) newTagDialog.findViewById(R.id.simpleEditText);
+		nameField.setText("");
 	}
 }


### PR DESCRIPTION
It took a bit of doing but TagManagerActivity is now working in a way that should be testable by the TagsEditText file. I ended up adding attributes for the dialogs to the activity (among other changes), mostly so the tests would be doable.
If you need to do a test involving dialogs see these files, I still don't know if the tests actually pass since the rest of the test files don't yet compile.