### PR TITLE
Reworked everything to get rid of singleton controllers.

### DIFF
--- a/Team1TravelExpenseApp/res/layout/activity_login.xml
+++ b/Team1TravelExpenseApp/res/layout/activity_login.xml
@@ -38,7 +38,7 @@
         android:layout_below="@+id/userNameField"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="84dp"
-        android:onClick="userLogin"
+        android:onClick="claimantLogin"
         android:text="User" />
 
     <Button

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Approver.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Approver.java
@@ -1,0 +1,9 @@
+package ca.ualberta.cs.team1travelexpenseapp;
+
+public class Approver extends User {
+	Approver(String name){
+		super(name);
+	}
+	
+	
+}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
@@ -45,7 +45,6 @@ public class ApproverClaimInfo extends Activity {
 
 	public void onStart() {
 		super.onStart();
-		UserSingleton.
-		info.setText(user.getCurrentClaim.toString());
+		info.setText(user.getCurrentClaim().toString());
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
@@ -25,10 +25,13 @@ import android.widget.TextView;
  */
 public class ApproverClaimInfo extends Activity {
 	TextView info;
+	private User user;
 		
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		user = UserSingleton.getUserSingleton().getUser();
+		
 		setContentView(R.layout.activity_approver_claim_info);
 		info = (TextView) findViewById(R.id.ApproverClaimInfoTextView);
 	}
@@ -42,6 +45,7 @@ public class ApproverClaimInfo extends Activity {
 
 	public void onStart() {
 		super.onStart();
-		info.setText(ClaimListController.getCurrentClaim().toString());
+		UserSingleton.
+		info.setText(user.getCurrentClaim.toString());
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimInfo.java
@@ -25,12 +25,12 @@ import android.widget.TextView;
  */
 public class ApproverClaimInfo extends Activity {
 	TextView info;
-	private User user;
+	private Claim currentClaim;
 		
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		user = UserSingleton.getUserSingleton().getUser();
+		currentClaim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 		
 		setContentView(R.layout.activity_approver_claim_info);
 		info = (TextView) findViewById(R.id.ApproverClaimInfoTextView);
@@ -45,6 +45,6 @@ public class ApproverClaimInfo extends Activity {
 
 	public void onStart() {
 		super.onStart();
-		info.setText(user.getCurrentClaim().toString());
+		info.setText(currentClaim.toString());
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
@@ -44,7 +44,7 @@ public class ApproverClaimsListActivity extends Activity {
 	private ClaimList claimList;
  	public  AlertDialog editClaimDialog;
  	private Listener listener;
- 	public  User user;
+ 	public  Approver user;
 
  	
 	
@@ -58,7 +58,7 @@ public class ApproverClaimsListActivity extends Activity {
 		//the claimant name, the starting date of travel, the destination(s) of travel, the 
 		//claim status, total currency amounts, and any approver name.
 
-		user=UserSingleton.getUserSingleton().getUser();
+		user=(Approver)UserSingleton.getUserSingleton().getUser();
       //taken from https://github.com/abramhindle/student-picker (March 15, 2015) and modified
 		// TODO: show approved claims and make sure the approver doesn't see their own claims
 		final ListView claimsListView = (ListView) findViewById(R.id.approverclaimList);

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
@@ -58,11 +58,11 @@ public class ApproverClaimsListActivity extends Activity {
 		//the claimant name, the starting date of travel, the destination(s) of travel, the 
 		//claim status, total currency amounts, and any approver name.
 
-        
+		user=UserSingleton.getUserSingleton().getUser();
       //taken from https://github.com/abramhindle/student-picker (March 15, 2015) and modified
 		// TODO: show approved claims and make sure the approver doesn't see their own claims
 		final ListView claimsListView = (ListView) findViewById(R.id.approverclaimList);
-  		claimList=ClaimListController.getSubmittedClaims();
+  		claimList=user.getClaimList();
   		Collection<Claim> claims = claimList.getClaims();
 		final ArrayList<Claim> claimsList = new ArrayList<Claim>(claims);
   		final ArrayAdapter<Claim> claimsAdapter = new ArrayAdapter<Claim>(this, android.R.layout.simple_list_item_1, claimsList);
@@ -72,7 +72,7 @@ public class ApproverClaimsListActivity extends Activity {
 			@Override
 			public void update() {
 				claimsList.clear();
-		  		claimList=ClaimListController.getSubmittedClaims();
+		  		claimList=user.getClaimList();
 				Collection<Claim> claims = claimList.getClaims();
 				claimsList.addAll(claims);
 				claimsAdapter.notifyDataSetChanged();
@@ -84,7 +84,7 @@ public class ApproverClaimsListActivity extends Activity {
         
         claimsListView.setOnItemClickListener(new OnItemClickListener(){
         	public void onItemClick( AdapterView<?> Parent, View v, int position, long id){
-        		ClaimListController.setCurrentClaim(claimsAdapter.getItem(position));
+        		user.setCurrentClaim(claimsAdapter.getItem(position));
         		Intent intent= new Intent(getBaseContext(),ApproverExpenseListActivity.class);	
         		startActivity(intent);
         	}
@@ -97,7 +97,7 @@ public class ApproverClaimsListActivity extends Activity {
 	public void onStart(){
 		super.onStart();
 		final ListView claimsListView = (ListView) findViewById(R.id.approverclaimList);
-  		claimList=ClaimListController.getSubmittedClaims();
+  		claimList=user.getClaimList();
   		Collection<Claim> claims = claimList.getClaims();
 		final ArrayList<Claim> claimsList = new ArrayList<Claim>(claims);
   		final ArrayAdapter<Claim> claimsAdapter = new ArrayAdapter<Claim>(this, android.R.layout.simple_list_item_1, claimsList);

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
@@ -44,6 +44,7 @@ public class ApproverClaimsListActivity extends Activity {
  	private ListView mainListView;
  	public  AlertDialog editClaimDialog;
  	private Listener listener;
+ 	public  User user;
 
  	
 	

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
@@ -16,6 +16,7 @@ package ca.ualberta.cs.team1travelexpenseapp;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Currency;
 
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -84,7 +85,7 @@ public class ApproverClaimsListActivity extends Activity {
         
         claimsListView.setOnItemClickListener(new OnItemClickListener(){
         	public void onItemClick( AdapterView<?> Parent, View v, int position, long id){
-        		user.setCurrentClaim(claimsAdapter.getItem(position));
+        		SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(claimsAdapter.getItem(position));
         		Intent intent= new Intent(getBaseContext(),ApproverExpenseListActivity.class);	
         		startActivity(intent);
         	}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverClaimsListActivity.java
@@ -42,7 +42,6 @@ public class ApproverClaimsListActivity extends Activity {
 
 	
 	private ClaimList claimList;
- 	private ListView mainListView;
  	public  AlertDialog editClaimDialog;
  	private Listener listener;
  	public  User user;

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
@@ -54,6 +54,7 @@ public class ApproverExpenseListActivity extends Activity {
 		
 		// display current claims expense items 
 		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
+		claimListController.setCurrentClaim(claim);
 		
 		expenseListView = (ListView) findViewById(R.id.approverExpensesList);
         expenselistAdapter = new ArrayAdapter<Expense>(this, android.R.layout.simple_list_item_1, 

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
@@ -40,6 +40,7 @@ import android.widget.TextView;
 public class ApproverExpenseListActivity extends Activity {
 
 	public Claim claim;
+	private ClaimListController claimListController;
 	private ArrayAdapter<Expense> expenselistAdapter ;
  	private ListView expenseListView ;
  	private User user;
@@ -48,10 +49,11 @@ public class ApproverExpenseListActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		user=UserSingleton.getUserSingleton().getUser();
+		claimListController=new ClaimListController(user.getClaimList());
 		setContentView(R.layout.approver_display_expenses);
 		
 		// display current claims expense items 
-		claim = ClaimListController.getCurrentClaim();
+		claim = user.getCurrentClaim();
 		
 		expenseListView = (ListView) findViewById(R.id.approverExpensesList);
         expenselistAdapter = new ArrayAdapter<Expense>(this, android.R.layout.simple_list_item_1, 
@@ -92,7 +94,7 @@ public class ApproverExpenseListActivity extends Activity {
 	 * @param v The button clicked by the user.
 	 */
 	public void onApproveClick(View v) {
-		ClaimListController.onApproveClick();
+		claimListController.onApproveClick();
 		finish();
 	}
 	
@@ -101,7 +103,7 @@ public class ApproverExpenseListActivity extends Activity {
 	 * @param v The button clicked by the user.
 	 */
 	public void onReturnClick(View v) {
-		ClaimListController.onReturnClick();
+		claimListController.onReturnClick();
 		finish();
 	}
 	
@@ -135,7 +137,7 @@ public class ApproverExpenseListActivity extends Activity {
 		public void onClick(DialogInterface dialog, int whichButton) {
 		  String value = input.getText().toString();
 		  // save the comment
-		  ClaimListController.onCommentClick(value);
+		  claimListController.onCommentClick(value);
 		  }
 		});
 

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
@@ -53,7 +53,7 @@ public class ApproverExpenseListActivity extends Activity {
 		setContentView(R.layout.approver_display_expenses);
 		
 		// display current claims expense items 
-		claim = user.getCurrentClaim();
+		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 		
 		expenseListView = (ListView) findViewById(R.id.approverExpensesList);
         expenselistAdapter = new ArrayAdapter<Expense>(this, android.R.layout.simple_list_item_1, 

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ApproverExpenseListActivity.java
@@ -42,10 +42,12 @@ public class ApproverExpenseListActivity extends Activity {
 	public Claim claim;
 	private ArrayAdapter<Expense> expenselistAdapter ;
  	private ListView expenseListView ;
+ 	private User user;
  	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
+		user=UserSingleton.getUserSingleton().getUser();
 		setContentView(R.layout.approver_display_expenses);
 		
 		// display current claims expense items 

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Claim.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Claim.java
@@ -271,7 +271,7 @@ public class Claim implements Comparable<Claim>{
 	 * @param comment String to be added as comment.
 	 */
 	public void addComment(String comment) {
-		commentList.put(ClaimListController.getUser().getName(), comment);
+		commentList.put(UserSingleton.getUserSingleton().getUser().getName(), comment);
 	}
 
 	/**
@@ -398,9 +398,6 @@ public class Claim implements Comparable<Claim>{
 	 */
 	@Override
 	public int compareTo( Claim claim ) {
-		if (ClaimListController.getUserType().equals("Claimant")) {
-			return claim.startDate.compareTo(this.startDate);
-		}
 		return this.startDate.compareTo(claim.startDate);
 	}
 	

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
@@ -41,7 +41,7 @@ public class ClaimList {
 		claimList = new ArrayList<Claim>();
 		selectedTags = new ArrayList<Tag>();
 		listeners = new ArrayList<Listener>();
-		manager=new ClaimListManager(this);
+		manager=new ClaimListManager(this,UserSingleton.getUserSingleton().getUser().getName());
 	}
 	
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
@@ -32,7 +32,7 @@ public class ClaimList {
 	private ArrayList<Claim> claimList;
 	private ArrayList<Tag> selectedTags;
 	private ClaimListManager manager;
-	private ArrayList<Listener> listeners;
+	private transient ArrayList<Listener> listeners;
 	
 	/**
 	 * Create the ClaimList with new ArrayLists of Claims, selectedTags, and listeners.

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimList.java
@@ -41,7 +41,7 @@ public class ClaimList {
 		claimList = new ArrayList<Claim>();
 		selectedTags = new ArrayList<Tag>();
 		listeners = new ArrayList<Listener>();
-		manager=new ClaimListManager(this,UserSingleton.getUserSingleton().getUser().getName());
+		manager=new ClaimListManager(this);
 	}
 	
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
@@ -42,57 +42,48 @@ public class ClaimListController {
 	/**
 	 * The apps main list of claims
 	 */
-	protected static ClaimList claimsList = null;
+	protected ClaimList claimsList;
 	
 	/**
 	 * all claims in the system 
 	 */
-	protected static ClaimList allClaims = null;
+	protected ClaimList allClaims;
 	/**
 	 * The list of claims that are to be displayed in a view
 	 */
-	protected static ClaimList displayedClaimList = null;
+	protected ClaimList displayedClaimList;
 	/**
 	 * The claim that is currently in use when the user selects a claim for viewing/modification
 	 */
-	protected static Claim currentClaim = null;
+	protected Claim currentClaim;
 	/**
 	 * The current user of the app
 	 */
-	protected static User user = null;
+	protected User user;
 	/**
 	 * Gets the current claims list
 	 * @return returns the current claims list
 	 */
-	public static ClaimList getClaimList() { 
-		if (claimsList == null) {
-			claimsList = new ClaimList();
-		}
-		
-		return claimsList;
+	
+	public ClaimListController(ClaimList claimList){
+		this.claimsList=claimList;
 	}
+	
+	public ClaimList getClaimList() { 
+		return this.claimsList;
+	}
+	
 	/**
-	 * Gets the all claims list
-	 * @return returns the all claims list
+	 * Updates the current claim to be updated
+	 * @param newClaim the claim to be updated
 	 */
-	public static ClaimList getAllClaimList() { 
-		if (allClaims == null) {
-			allClaims = new ClaimList();
+	public void updateCurrentClaim(Claim newClaim) {
+		if (currentClaim == null) {
+			throw new RuntimeException("no current claim");
 		}
-		
-		return allClaims;
+		claimsList.updateClaim(currentClaim, newClaim);
 	}
-	/**
-	 * Gets the displayed claims list
-	 * @return returns the displayed claims list
-	 */
-	public static ClaimList getDisplayedClaims() {
-		if (displayedClaimList == null) {
-			displayedClaimList = getClaimList();
-		}
-		
-		return displayedClaimList;
-	}
+	
 	/**
 	 * Sets the current claim's status to returned and add the users name to the list of approvers
 	 */
@@ -103,36 +94,12 @@ public class ClaimListController {
 		currentClaim.getApproverList().add(user);
 		currentClaim.setApproverList(currentClaim.getApproverList());
 	}
-	/**
-	 * Sets the displayed claims list
-	 * @param claims The claims list to be displayed
-	 */
-	public static void setDisplayedClaims(ClaimList claims) {
-		displayedClaimList = claims;
-	}
-	/**
-	 * Updates the current claim to be updated
-	 * @param newClaim the claim to be updated
-	 */
-	public static void updateCurrentClaim(Claim newClaim) {
-		if (currentClaim == null) {
-			throw new RuntimeException("no current claim");
-		}
-		claimsList.updateClaim(currentClaim, newClaim);
-	}
-	/**
-	 * Sets the current claim that is selected by user
-	 * DOES NOT UPDATE CLAIMS LIST 
-	 * @param claim The claim that is selected
-	 */
-	public static void setCurrentClaim(Claim claim){
-		currentClaim=claim;
-	}
+	
 	/**
 	 * Deletes a claim
 	 * @param claim The claim to be deleted
 	 */
-	public static void deleteClaim(Claim claim){
+	public void deleteClaim(Claim claim){
 		ArrayList<Claim> claims=claimsList.getClaims();
 		claims.remove(claim);
 		claimsList.setClaimList(claims);
@@ -144,12 +111,12 @@ public class ClaimListController {
 	 * Redirects to the function within the ClaimListController
 	 * @param activity 
 	 */
-	public static void onSubmitClick (final ClaimantExpenseListActivity activity) {
+	public void onSubmitClick (final ClaimantExpenseListActivity activity) {
 	
 		
 		boolean expensesFlag = false;
 		boolean expensesComplete = true;
-		for(Expense expense: ClaimListController.getCurrentClaim().getExpenseList().getExpenses()){
+		for(Expense expense: getCurrentClaim().getExpenseList().getExpenses()){
 			//flag check 
 			if(expense.isFlagged() == true){
 				expensesFlag = true;
@@ -160,16 +127,16 @@ public class ClaimListController {
 			}
 		}
 		
-		if(ClaimListController.getCurrentClaim().isComplete() == false 
+		if(getCurrentClaim().isComplete() == false 
 				|| expensesFlag == true || expensesComplete == false){
 			
 			AlertDialog.Builder submitBuilder = new AlertDialog.Builder(activity);
 			submitBuilder.setNeutralButton("OK", new DialogInterface.OnClickListener() {
 		           public void onClick(DialogInterface dialog, int id) {
 		               //Do nothing
-		        	   Claim submittedClaim = ClaimListController.getCurrentClaim();
+		        	   Claim submittedClaim = getCurrentClaim();
 						submittedClaim.setStatus(Status.submitted);
-						ClaimListController.updateCurrentClaim(submittedClaim);
+						updateCurrentClaim(submittedClaim);
 		        	   
 		        	  // ClaimListController.getCurrentClaim().setStatus(Status.submitted);
 		        	   Toast.makeText(activity.getApplicationContext(),"Claim submitted", Toast.LENGTH_LONG).show();
@@ -190,12 +157,12 @@ public class ClaimListController {
 
 		}else{
 			
-			if(ClaimListController.getCurrentClaim().getStatus()!= Status.submitted && ClaimListController.getCurrentClaim().getStatus() != Status.approved){
+			if(getCurrentClaim().getStatus()!= Status.submitted && getCurrentClaim().getStatus() != Status.approved){
 				
 				//ClaimListController.getCurrentClaim().setStatus(Status.submitted);
-				Claim submittedClaim = ClaimListController.getCurrentClaim();
+				Claim submittedClaim = getCurrentClaim();
 				submittedClaim.setStatus(Status.submitted);
-				ClaimListController.updateCurrentClaim(submittedClaim);
+				updateCurrentClaim(submittedClaim);
 				
 				Toast.makeText(activity.getApplicationContext(),"Claim submitted", Toast.LENGTH_LONG).show();
 				//push online here
@@ -220,7 +187,7 @@ public class ClaimListController {
 	 * The onClick method for the save button when editing/adding claims
 	 * @param activity The edit claim activity containing the views
 	 */
-	public static void onSaveClick(EditClaimActivity activity) {
+	public void onSaveClick(EditClaimActivity activity) {
 		TextView   nameView   = (TextView) activity.findViewById(R.id.claimNameBody);
 		String     nameText   = nameView.getText().toString();
 		
@@ -245,13 +212,13 @@ public class ClaimListController {
 		
 				Claim newClaim=new Claim(nameText, fromDate, endDate);
 				newClaim.setClaimTagList(claimTags);
-				ClaimListController.updateCurrentClaim(newClaim);
+				updateCurrentClaim(newClaim);
 				
 		
 		}else{
 			Claim newClaim = getCurrentClaim();
 			newClaim.setClaimTagList(claimTags);
-			ClaimListController.updateCurrentClaim(newClaim);
+			updateCurrentClaim(newClaim);
 			
 		}
 		
@@ -272,8 +239,8 @@ public class ClaimListController {
 	 * The onClick method for adding a claim
 	 * @param activity The activity which holds the add claim button
 	 */
-	public static void onAddClaimClick(ClaimantClaimsListActivity activity) {
-		ClaimListController.addClaim(new Claim());
+	public void onAddClaimClick(ClaimantClaimsListActivity activity) {
+		addClaim(new Claim());
 		Intent intent = new Intent(activity, EditClaimActivity.class);
 		activity.startActivity(intent);
 		
@@ -282,10 +249,10 @@ public class ClaimListController {
 	 * The onClick method for adding a destination/reason pair to a claim
 	 * @param activity The activity containing the add destination/reason button
 	 */
-	public static void onAddDestinationClick(EditClaimActivity activity) {
+	public void onAddDestinationClick(EditClaimActivity activity) {
 		EditText destination = (EditText) activity.findViewById(R.id.claimDestinationBody);
 		EditText reason      = (EditText) activity.findViewById(R.id.claimReasonBody);
-		Claim claim = ClaimListController.getCurrentClaim();
+		Claim claim = getCurrentClaim();
 		Map<String, String> drlist = claim.getDestinationReasonList();
 		drlist.put(destination.getText().toString(), reason.getText().toString());
 		destination.setText("");
@@ -295,67 +262,53 @@ public class ClaimListController {
 	 * The getter for the currently selected claim
 	 * @return Returns the current claim selected
 	 */
-	public static Claim getCurrentClaim() {
+	public Claim getCurrentClaim() {
 		return currentClaim;
 	}
 	/**
 	 * Sets the current user 
 	 * @param theUser The user that is to be set as the current user
 	 */
-	public static void setUser(User theUser) {
+	public void setUser(User theUser) {
 		user = theUser; 
 	}
 	/**
 	 * Get the current user
 	 * @return The current user
 	 */
-	public static User getUser() {
+	public User getUser() {
 		return user; 
 	}
 	/**
 	 * Get the number of claims
 	 * @return The number of claims
 	 */
-	public static int getClaimCount() {
+	public int getClaimCount() {
 		return claimsList.getClaims().size();
 	}
 	/**
 	 * Allows a claim to be added to the claims list
 	 * @param claim The claim to be added
 	 */
-	public static void addClaim(Claim claim) {
+	public void addClaim(Claim claim) {
 		ArrayList<Claim> claimArray=getClaimList().getClaims();
 		setCurrentClaim(claim);
 		claimArray.add(claim);
-		getAllClaimList();
-		allClaims.addClaim(claim);
 		//displays an empty claim in claim list 
 		claimsList.setClaimList(claimArray);
 		
 	}
-	/**
-	 * Get the claims that are submitted
-	 * @return returns a list of the currently submitted claims
-	 */
-	public static ClaimList getSubmittedClaims() {
-		// TODO Auto-generated method stub
-		ClaimList submittedclaims = new ClaimList();
-		
-		for (Claim item: getAllClaimList().getClaims()) {
-			
-			if ((item.status.equals(Claim.Status.submitted))) {
-				submittedclaims.addClaim(item);
-			}
-		}
-		//claimsList.setClaimList(submittedclaims.getClaims());
-		return submittedclaims;
+	private void setCurrentClaim(Claim claim) {
+		currentClaim=claim;	
 	}
+
+	
 	/**
 	 * The onClick method for deleting a claim
 	 */
-	public static void onRemoveClaimClick() {
+	public void onRemoveClaimClick() {
 		
-		if(ClaimListController.getCurrentClaim().getStatus()!= Status.submitted && ClaimListController.getCurrentClaim().getStatus() != Status.approved){
+		if(getCurrentClaim().getStatus()!= Status.submitted && getCurrentClaim().getStatus() != Status.approved){
 		
 			ArrayList<Claim> claims = getClaimList().getClaims();
 			claims.remove(currentClaim);
@@ -368,16 +321,16 @@ public class ClaimListController {
 	 * The onClick method for the approve button
 	 * Sets the claims status to approved, and adds the user to the list of approvers
 	 */
-	public static void onApproveClick() {
+	public void onApproveClick() {
 		// denote the claim status as approved and set approver
 		//name as the approver for the expense claim.
-		Claim approvedClaim =getCurrentClaim();		
+		Claim approvedClaim = getCurrentClaim();		
 		approvedClaim.setStatus(Status.approved);
 		
 		ArrayList<User> approverList = approvedClaim.getApproverList();
 		approverList.add(user);
 		approvedClaim.setApproverList(approverList);
-		ClaimListController.updateCurrentClaim(approvedClaim);
+		updateCurrentClaim(approvedClaim);
 		
 		
 	}
@@ -385,7 +338,7 @@ public class ClaimListController {
 	 * The onClick method for the return button
 	 * Sets the claim status as returned and adds user to approver list
 	 */
-	public static void onReturnClick() {
+	public void onReturnClick() {
 		currentClaim.setStatus(Status.returned);
 		currentClaim.getApproverList().add(user);
 		currentClaim.setApproverList(currentClaim.getApproverList());
@@ -395,13 +348,13 @@ public class ClaimListController {
 	 * Adds a comment to a claim
 	 * @param comment The comment to be added
 	 */
-	public static void onCommentClick(String comment) {
+	public void onCommentClick(String comment) {
 		currentClaim.getCommentList().put(user.getName(), comment);
 	}
 	/**
 	 * Save the data to the elastic server
 	 */
-	public static void SaveToOnline() {
+	public void SaveToOnline() {
 		// TODO Auto-generated method stub
 		
 	}
@@ -417,12 +370,8 @@ public class ClaimListController {
     /**
      * Reset the claimList to a new claimList removing all it's old contents.
      */
-    public static void clearClaimList(){
+    public void clearClaimList(){
     	claimsList=new ClaimList();
     }
-	public static String getUserType() {
-		// TODO Auto-generated method stub
-		return user.type();
-	}
 	
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
@@ -162,8 +162,7 @@ public class ClaimListController {
 				
 				Toast.makeText(activity.getApplicationContext(),"Claim submitted", Toast.LENGTH_LONG).show();
 				//push online here
-				Intent intent = new Intent(activity, ClaimantClaimsListActivity.class);
-				activity.startActivity(intent);
+				activity.finish();
 			}
 			else{
 				Toast.makeText(activity.getApplicationContext(),"Claim can not be submitted", Toast.LENGTH_SHORT).show();

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListController.java
@@ -45,10 +45,6 @@ public class ClaimListController {
 	protected ClaimList claimsList;
 	
 	/**
-	 * all claims in the system 
-	 */
-	protected ClaimList allClaims;
-	/**
 	 * The list of claims that are to be displayed in a view
 	 */
 	protected ClaimList displayedClaimList;
@@ -240,7 +236,9 @@ public class ClaimListController {
 	 * @param activity The activity which holds the add claim button
 	 */
 	public void onAddClaimClick(ClaimantClaimsListActivity activity) {
-		addClaim(new Claim());
+		Claim claim = new Claim();
+		addClaim(claim);
+		SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(claim);
 		Intent intent = new Intent(activity, EditClaimActivity.class);
 		activity.startActivity(intent);
 		
@@ -298,7 +296,8 @@ public class ClaimListController {
 		claimsList.setClaimList(claimArray);
 		
 	}
-	private void setCurrentClaim(Claim claim) {
+	
+	public void setCurrentClaim(Claim claim) {
 		currentClaim=claim;	
 	}
 
@@ -312,7 +311,6 @@ public class ClaimListController {
 		
 			ArrayList<Claim> claims = getClaimList().getClaims();
 			claims.remove(currentClaim);
-			allClaims.getClaims().remove(currentClaim);
 			claimsList.setClaimList(claims);
 		}
 		

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListManager.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListManager.java
@@ -17,13 +17,15 @@ import com.google.gson.reflect.TypeToken;
 public class ClaimListManager {
 	private ClaimList claimList;
 	private Context context;
+	private String userName;
 	
 	/**
 	 * Initialize with the claimList to be managed.
 	 * @param claimList The ClaimList to saved from and loaded to
 	 */
-	ClaimListManager(ClaimList claimList){
+	ClaimListManager(ClaimList claimList, String userName){
 		this.claimList=claimList;
+		this.userName=userName;
 	}
 	
 	/**
@@ -31,7 +33,7 @@ public class ClaimListManager {
 	 */
 	public void saveClaims(){
 		Gson gson = new Gson();
-		String saveFile=ClaimListController.getUser().getName()+"_claims.sav";
+		String saveFile=userName+"_claims.sav";
 		try {
 			FileOutputStream fos = context.openFileOutput(saveFile, 0);
 			OutputStreamWriter osw = new OutputStreamWriter(fos);
@@ -54,7 +56,7 @@ public class ClaimListManager {
 	public void loadClaims(){
 		Gson gson = new Gson();
 		ArrayList<Claim> claims=new ArrayList <Claim>();
-		String saveFile=ClaimListController.getUser().getName()+"_claims.sav";
+		String saveFile=userName+"_claims.sav";
 		try {
 			FileInputStream fis = context.openFileInput(saveFile);
 			InputStreamReader in =new InputStreamReader(fis);

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListManager.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimListManager.java
@@ -17,15 +17,17 @@ import com.google.gson.reflect.TypeToken;
 public class ClaimListManager {
 	private ClaimList claimList;
 	private Context context;
-	private String userName;
+	private String saveFile;
 	
+	
+
 	/**
 	 * Initialize with the claimList to be managed.
 	 * @param claimList The ClaimList to saved from and loaded to
 	 */
-	ClaimListManager(ClaimList claimList, String userName){
+	ClaimListManager(ClaimList claimList){
 		this.claimList=claimList;
-		this.userName=userName;
+		this.saveFile="claims.sav";
 	}
 	
 	/**
@@ -33,7 +35,6 @@ public class ClaimListManager {
 	 */
 	public void saveClaims(){
 		Gson gson = new Gson();
-		String saveFile=userName+"_claims.sav";
 		try {
 			FileOutputStream fos = context.openFileOutput(saveFile, 0);
 			OutputStreamWriter osw = new OutputStreamWriter(fos);
@@ -56,7 +57,6 @@ public class ClaimListManager {
 	public void loadClaims(){
 		Gson gson = new Gson();
 		ArrayList<Claim> claims=new ArrayList <Claim>();
-		String saveFile=userName+"_claims.sav";
 		try {
 			FileInputStream fis = context.openFileInput(saveFile);
 			InputStreamReader in =new InputStreamReader(fis);
@@ -82,5 +82,9 @@ public class ClaimListManager {
 	 */
 	public void setContext(Context context){
 		this.context=context;
+	}
+	
+	public void setSaveFile(String saveFile) {
+		this.saveFile = saveFile;
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Claimant.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/Claimant.java
@@ -1,0 +1,22 @@
+package ca.ualberta.cs.team1travelexpenseapp;
+
+public class Claimant extends User {
+	private TagList tagList;
+	
+	
+	Claimant(String name){
+		super(name);
+		this.tagList= new TagList();
+	}
+
+
+	public TagList getTagList() {
+		return tagList;
+	}
+
+
+	public void setTagList(TagList tagList) {
+		this.tagList = tagList;
+	}
+	
+}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
@@ -120,7 +120,8 @@ public class ClaimantClaimsListActivity extends Activity {
        mainListView.setOnItemLongClickListener(new OnItemLongClickListener(){
         	
     		public boolean onItemLongClick( AdapterView<?> Parent, View v, int position, long id){
-    			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(claimsAdapter.getItem(position));
+    			final Claim clickedClaim=claimsAdapter.getItem(position);
+    			claimListController.setCurrentClaim(clickedClaim);
     			
     			//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html (March 15, 2015)
 				 AlertDialog.Builder editClaimDialogBuilder = new AlertDialog.Builder(ClaimantClaimsListActivity.this);
@@ -128,7 +129,7 @@ public class ClaimantClaimsListActivity extends Activity {
 				 editClaimDialogBuilder.setPositiveButton("edit", new DialogInterface.OnClickListener() {
 
 			           public void onClick(DialogInterface dialog, int id) {		
-			    		
+			        	   SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(clickedClaim);
 			        	   Intent edit = new Intent(getBaseContext(), EditClaimActivity.class);
 			        	   startActivity(edit);
 			    					
@@ -138,8 +139,8 @@ public class ClaimantClaimsListActivity extends Activity {
 				editClaimDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 			           public void onClick(DialogInterface dialog, int id) {
 			        	   
-			        	   if(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getStatus()!= Status.submitted){
-			        			   if (SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getStatus() != Status.approved){
+			        	   if(claimListController.getCurrentClaim().getStatus()!= Status.submitted){
+			        			   if (claimListController.getCurrentClaim().getStatus() != Status.approved){
 			        				   claimListController.onRemoveClaimClick();
 			        			   }
 			        			   else{

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
@@ -21,6 +21,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Collections;
 import java.util.Comparator;
+
 import ca.ualberta.cs.team1travelexpenseapp.Claim.Status;
 import android.app.Activity;
 import android.app.AlertDialog;
@@ -58,6 +59,7 @@ public class ClaimantClaimsListActivity extends Activity {
  	
  	public static Activity activity;
  	private static ArrayAdapter<Claim> claimsAdapter;
+ 	private Claimant user;
 
  	
 	
@@ -65,11 +67,14 @@ public class ClaimantClaimsListActivity extends Activity {
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.claimant_activity_main);
+		
+		user=(Claimant) UserSingleton.getUserSingleton().getUser();
+		
 		activity = this;
 		
 		//set up the tag filter spinner
 		final MultiSelectionSpinner tagSpinner= (MultiSelectionSpinner) findViewById(R.id.claimFilterSpinner);
-		tagSpinner.setItems(TagListController.getTagList().getTags());
+		tagSpinner.setItems(user.getTagList().getTags());
 		//ArrayList<Tag> claimTags=ClaimListController.getCurrentClaim().getClaimTagList();
 		//tagSpinner.setSelection(claimTags);
 
@@ -81,7 +86,7 @@ public class ClaimantClaimsListActivity extends Activity {
 		mainListView = (ListView) findViewById(R.id.claimsList);
         
         //taken from https://github.com/abramhindle/student-picker and modified
-  		claimList=ClaimListController.getClaimList();
+  		claimList=user.getClaimList();
   		Collection<Claim> claims = claimList.getClaims();
   		displayList = new ArrayList<Claim>(claims);
   		claimsAdapter = new ArrayAdapter<Claim>(this, android.R.layout.simple_list_item_1, displayList);
@@ -92,7 +97,7 @@ public class ClaimantClaimsListActivity extends Activity {
 			@Override
 			public void update() {
 				displayList.clear();
-				Collection<Claim> claims = ClaimListController.getClaimList().getClaims();
+				Collection<Claim> claims = user.getClaimList().getClaims();
 		  		displayList.addAll(claims);
 				claimsAdapter.notifyDataSetChanged();
 			}
@@ -103,7 +108,7 @@ public class ClaimantClaimsListActivity extends Activity {
         
         mainListView.setOnItemClickListener(new OnItemClickListener(){
         	public void onItemClick( AdapterView<?> Parent, View v, int position, long id){
-        		ClaimListController.setCurrentClaim(claimsAdapter.getItem(position));
+        		user.setCurrentClaim(claimsAdapter.getItem(position));
         		Intent intent= new Intent(getBaseContext(),ClaimantExpenseListActivity.class);	
         		startActivity(intent);
         	}
@@ -112,7 +117,7 @@ public class ClaimantClaimsListActivity extends Activity {
        mainListView.setOnItemLongClickListener(new OnItemLongClickListener(){
         	
     		public boolean onItemLongClick( AdapterView<?> Parent, View v, int position, long id){
-    			 ClaimListController.setCurrentClaim(claimsAdapter.getItem(position));
+    			 user.setCurrentClaim(claimsAdapter.getItem(position));
     			
     			//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html (March 15, 2015)
 				 AlertDialog.Builder editClaimDialogBuilder = new AlertDialog.Builder(ClaimantClaimsListActivity.this);
@@ -130,9 +135,9 @@ public class ClaimantClaimsListActivity extends Activity {
 				editClaimDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 			           public void onClick(DialogInterface dialog, int id) {
 			        	   
-			        	   if(ClaimListController.getCurrentClaim().getStatus()!= Status.submitted){
-			        			   if (ClaimListController.getCurrentClaim().getStatus() != Status.approved){
-			        				   ClaimListController.onRemoveClaimClick();
+			        	   if(user.getCurrentClaim().getStatus()!= Status.submitted){
+			        			   if (user.getCurrentClaim().getStatus() != Status.approved){
+			        				   user.onRemoveClaimClick();
 			        			   }
 			        			   else{
 			        				   Toast.makeText(getApplicationContext(),"This claim can not be deleted", Toast.LENGTH_SHORT).show();

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantClaimsListActivity.java
@@ -60,6 +60,7 @@ public class ClaimantClaimsListActivity extends Activity {
  	public static Activity activity;
  	private static ArrayAdapter<Claim> claimsAdapter;
  	private Claimant user;
+ 	private ClaimListController claimListController;
 
  	
 	
@@ -69,6 +70,8 @@ public class ClaimantClaimsListActivity extends Activity {
 		setContentView(R.layout.claimant_activity_main);
 		
 		user=(Claimant) UserSingleton.getUserSingleton().getUser();
+		claimListController= new ClaimListController(user.getClaimList());
+		
 		
 		activity = this;
 		
@@ -108,7 +111,7 @@ public class ClaimantClaimsListActivity extends Activity {
         
         mainListView.setOnItemClickListener(new OnItemClickListener(){
         	public void onItemClick( AdapterView<?> Parent, View v, int position, long id){
-        		user.setCurrentClaim(claimsAdapter.getItem(position));
+        		SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(claimsAdapter.getItem(position));
         		Intent intent= new Intent(getBaseContext(),ClaimantExpenseListActivity.class);	
         		startActivity(intent);
         	}
@@ -117,7 +120,7 @@ public class ClaimantClaimsListActivity extends Activity {
        mainListView.setOnItemLongClickListener(new OnItemLongClickListener(){
         	
     		public boolean onItemLongClick( AdapterView<?> Parent, View v, int position, long id){
-    			 user.setCurrentClaim(claimsAdapter.getItem(position));
+    			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentClaim(claimsAdapter.getItem(position));
     			
     			//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html (March 15, 2015)
 				 AlertDialog.Builder editClaimDialogBuilder = new AlertDialog.Builder(ClaimantClaimsListActivity.this);
@@ -135,9 +138,9 @@ public class ClaimantClaimsListActivity extends Activity {
 				editClaimDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 			           public void onClick(DialogInterface dialog, int id) {
 			        	   
-			        	   if(user.getCurrentClaim().getStatus()!= Status.submitted){
-			        			   if (user.getCurrentClaim().getStatus() != Status.approved){
-			        				   user.onRemoveClaimClick();
+			        	   if(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getStatus()!= Status.submitted){
+			        			   if (SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getStatus() != Status.approved){
+			        				   claimListController.onRemoveClaimClick();
 			        			   }
 			        			   else{
 			        				   Toast.makeText(getApplicationContext(),"This claim can not be deleted", Toast.LENGTH_SHORT).show();
@@ -195,7 +198,7 @@ public class ClaimantClaimsListActivity extends Activity {
 	 * @param v The button clicked by the user.
 	 */
 	public void onAddClaimClick(View v) {
-		ClaimListController.onAddClaimClick(this);
+		claimListController.onAddClaimClick(this);
 	}
 	
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantCommentActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantCommentActivity.java
@@ -29,12 +29,14 @@ public class ClaimantCommentActivity extends Activity {
 	
 	Claim claim;
 	TextView comments;
+	User user;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_claimant_comment);
-		claim = ClaimListController.getCurrentClaim();
+		user=UserSingleton.getUserSingleton().getUser();
+		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 	}
 	
 	public void onStart() {

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
@@ -66,11 +66,11 @@ public class ClaimantExpenseListActivity extends Activity {
 		
 		user=UserSingleton.getUserSingleton().getUser();
 		claimListController=new ClaimListController(user.getClaimList());
+		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 		expenseList=claim.getExpenseList();
 		expenseListController= new ExpenseListController(expenseList);
 		
-		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
-		if(claim.getStatus() == Status.submitted || claim.getStatus() ==Status.approved){
+		if(claim.getStatus() == Status.submitted || claim.getStatus() == Status.approved){
 			
 			Button submitBT = (Button) findViewById(R.id.submitButton);
 			submitBT.setClickable(false);
@@ -118,7 +118,8 @@ public class ClaimantExpenseListActivity extends Activity {
 	    expenseListView.setOnItemLongClickListener(new OnItemLongClickListener(){
 	        	
 	    		public boolean onItemLongClick( AdapterView<?> Parent, View v, int position, long id){
-	    			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(expenselistAdapter.getItem(position));
+	    			final Expense clickedExpense=expenselistAdapter.getItem(position);
+	    			expenseListController.setCurrentExpense(clickedExpense);
 	    			
 	    			//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html (March 15, 2015)
 					 AlertDialog.Builder editExpenseDialogBuilder = new AlertDialog.Builder(ClaimantExpenseListActivity.this);
@@ -126,6 +127,7 @@ public class ClaimantExpenseListActivity extends Activity {
 					 editExpenseDialogBuilder.setPositiveButton("edit", new DialogInterface.OnClickListener() {
 				           public void onClick(DialogInterface dialog, int id) {
 				    			//if(ClaimListController.getCurrentClaim().getStatus()!= Status.submitted && ClaimListController.getCurrentClaim().getStatus() != Status.approved){
+				        	    SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(clickedExpense);
 				    			Intent edit = new Intent(getBaseContext(), EditExpenseActivity.class);
 				    			startActivity(edit);
 				    				

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
@@ -47,9 +47,12 @@ public class ClaimantExpenseListActivity extends Activity {
  	private ListView expenseListView ;
  	private Listener listener;
  	private ExpenseList expenseList;
+ 	private ExpenseListController expenseListController;
  	private TextView claimInfoHeader;
  	public AlertDialog editExpenseDialog;
  	public AlertDialog submitWarningDialog;
+ 	private User user;
+ 	private ClaimListController claimListController;
  	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
@@ -60,8 +63,13 @@ public class ClaimantExpenseListActivity extends Activity {
 		//in order of entry, showing for each expense item: the date the expense was incurred,
 		//the category, the textual description, amount spent, unit of currency, 
 		//and whether there is a photographic receipt.
-
-		claim=ClaimListController.getCurrentClaim();
+		
+		user=UserSingleton.getUserSingleton().getUser();
+		claimListController=new ClaimListController(user.getClaimList());
+		expenseList=claim.getExpenseList();
+		expenseListController= new ExpenseListController(expenseList);
+		
+		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 		if(claim.getStatus() == Status.submitted || claim.getStatus() ==Status.approved){
 			
 			Button submitBT = (Button) findViewById(R.id.submitButton);
@@ -71,7 +79,6 @@ public class ClaimantExpenseListActivity extends Activity {
 			
 			
 		}
-		expenseList=ExpenseListController.getCurrentExpenseList();
         expenseListView = (ListView) findViewById(R.id.claimantExpensesList);
 
         Collection<Expense> expenses = claim.getExpenseList().getExpenses();
@@ -95,14 +102,14 @@ public class ClaimantExpenseListActivity extends Activity {
 		
 		expenseList.addListener(listener);
 		listener.update();
-		ClaimListController.getClaimList().addListener(listener);
-		for (Listener i : ClaimListController.getClaimList().getListeners()) {
+		user.getClaimList().addListener(listener);
+		for (Listener i : user.getClaimList().getListeners()) {
 			expenseList.addListener(i);
 		}
 			
 		expenseListView.setOnItemClickListener(new OnItemClickListener(){
         	public void onItemClick( AdapterView<?> Parent, View v, int position, long id){
-        		ExpenseListController.setCurrentExpense(expenselistAdapter.getItem(position));
+        		SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(expenselistAdapter.getItem(position));
     			Intent edit = new Intent(getBaseContext(), EditExpenseActivity.class);
     			startActivity(edit);
         	}
@@ -111,7 +118,7 @@ public class ClaimantExpenseListActivity extends Activity {
 	    expenseListView.setOnItemLongClickListener(new OnItemLongClickListener(){
 	        	
 	    		public boolean onItemLongClick( AdapterView<?> Parent, View v, int position, long id){
-	    			 ExpenseListController.setCurrentExpense(expenselistAdapter.getItem(position));
+	    			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(expenselistAdapter.getItem(position));
 	    			
 	    			//taken and modified from http://developer.android.com/guide/topics/ui/dialogs.html (March 15, 2015)
 					 AlertDialog.Builder editExpenseDialogBuilder = new AlertDialog.Builder(ClaimantExpenseListActivity.this);
@@ -127,7 +134,7 @@ public class ClaimantExpenseListActivity extends Activity {
 				       });
 					editExpenseDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 				           public void onClick(DialogInterface dialog, int id) {
-				        	   ExpenseListController.onRemoveExpenseClick();
+				        	   expenseListController.onRemoveExpenseClick();
 				           }
 				       });
 					editExpenseDialogBuilder.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
@@ -166,7 +173,7 @@ public class ClaimantExpenseListActivity extends Activity {
 	 * @param v the view from the onClick
 	 */
 	public void onAddExpenseClick(View v) {
-		ExpenseListController.onAddExpenseClick(this);
+		expenseListController.onAddExpenseClick(this);
 	}
 	
 	/**
@@ -177,7 +184,7 @@ public class ClaimantExpenseListActivity extends Activity {
 	 */
 	public void onSubmitClick(View v) {
 		
-		ClaimListController.onSubmitClick(this);
+		claimListController.onSubmitClick(this);
 		
 	}
 	

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ClaimantExpenseListActivity.java
@@ -67,6 +67,7 @@ public class ClaimantExpenseListActivity extends Activity {
 		user=UserSingleton.getUserSingleton().getUser();
 		claimListController=new ClaimListController(user.getClaimList());
 		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
+		claimListController.setCurrentClaim(claim);
 		expenseList=claim.getExpenseList();
 		expenseListController= new ExpenseListController(expenseList);
 		

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditClaimActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditClaimActivity.java
@@ -47,16 +47,22 @@ public class EditClaimActivity extends Activity {
 
 	private TextView destList;
 	private Claim claim;
+	private Claimant user;
+	private ClaimListController claimListController;
+	
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_edit_claim);
+		user=(Claimant) UserSingleton.getUserSingleton().getUser();
+		claimListController=new ClaimListController(user.getClaimList());
 	}
 
 	//on start method that loads all of the CurrentClaim values into the editTexts
 	
 	protected void onStart(){
 		super.onStart();
+		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 			
 		final AlertDialog.Builder StatusAlert =  new AlertDialog.Builder(EditClaimActivity.this);
 		StatusAlert.setPositiveButton("OK",new OnClickListener() {
@@ -66,8 +72,8 @@ public class EditClaimActivity extends Activity {
 				dialog.dismiss();
 			}
 		});
-		if(ClaimListController.getCurrentClaim().getStatus()==Status.submitted
-				|| ClaimListController.getCurrentClaim().getStatus()==Status.approved){
+		if(claim.getStatus()==Status.submitted
+				|| claim.getStatus()==Status.approved){
 			
 			
 			EditText nameET = (EditText) findViewById(R.id.claimNameBody);
@@ -86,17 +92,16 @@ public class EditClaimActivity extends Activity {
 			addDestBT.setFocusable(false);
 			
 			StatusAlert.setMessage("ONLY TAGS may be edited in this claim as it is already"
-			+ ClaimListController.getCurrentClaim().getStatus().toString());
+			+ claim.getStatus().toString());
 			
 			StatusAlert.show();
 		}
-		claim = ClaimListController.getCurrentClaim();
 		
 		TextView nameView  = (TextView) findViewById(R.id.claimNameBody);
 		nameView.setText(claim.getClaimantName());
 		
 		MultiSelectionSpinner tagSpinner= (MultiSelectionSpinner) findViewById(R.id.claimTagSpinner);
-		tagSpinner.setItems(TagListController.getTagList().getTags());
+		tagSpinner.setItems(user.getTagList().getTags());
 		ArrayList<Tag> claimTags=claim.getClaimTagList();
 		tagSpinner.setSelection(claimTags);
 		
@@ -140,7 +145,7 @@ public class EditClaimActivity extends Activity {
 
 		//editing model happens in controller 
 	
-		ClaimListController.onSaveClick(this);
+		claimListController.onSaveClick(this);
 	}
 	/**
 	 * The onClick method for the button allowing the user to add a destination/reason pair to a claim
@@ -148,7 +153,7 @@ public class EditClaimActivity extends Activity {
 	 */
 	public void onAddDestinationClick(View v) {
 		
-		ClaimListController.onAddDestinationClick(this);
+		claimListController.onAddDestinationClick(this);
 		updateDestinationText();
 	}
 	/**
@@ -170,7 +175,7 @@ public class EditClaimActivity extends Activity {
 	
 	public void onDestroy(){
 		super.onDestroy();
-		ClaimListController.onSaveClick(this);
+		claimListController.onSaveClick(this);
 	}
 
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditClaimActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditClaimActivity.java
@@ -55,14 +55,15 @@ public class EditClaimActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_edit_claim);
 		user=(Claimant) UserSingleton.getUserSingleton().getUser();
+		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 		claimListController=new ClaimListController(user.getClaimList());
+		claimListController.setCurrentClaim(claim);
 	}
 
 	//on start method that loads all of the CurrentClaim values into the editTexts
 	
 	protected void onStart(){
 		super.onStart();
-		claim = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
 			
 		final AlertDialog.Builder StatusAlert =  new AlertDialog.Builder(EditClaimActivity.this);
 		StatusAlert.setPositiveButton("OK",new OnClickListener() {

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
@@ -54,10 +54,10 @@ public class EditExpenseActivity extends Activity {
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
-		setContentView(R.layout.activity_edit_expense);	
-		expenseList = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getExpenseList();
-		expense=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense();
+		setContentView(R.layout.activity_edit_expense);
 		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
+		expenseList = claim.getExpenseList();
+		expense=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense();
 		expenseListController=new ExpenseListController(expenseList);
 		
 		listener=new Listener() {			

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
@@ -69,6 +69,7 @@ public class EditExpenseActivity extends Activity {
 		};
 		
 		expenseList.addListener(listener);
+		
 	}
 
 	private void updateValues(){

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
@@ -46,13 +46,19 @@ import android.widget.Spinner;
  */
 public class EditExpenseActivity extends Activity {
 	private ExpenseList expenseList;
+	private ExpenseListController expenseListController;
+	private Expense expense;
 	private Listener listener;
+	private Claim claim;
 
 	@Override
 	protected void onCreate(Bundle savedInstanceState) {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_edit_expense);	
-		expenseList = ExpenseListController.getCurrentExpenseList();
+		expenseList = SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().getExpenseList();
+		expense=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense();
+		claim=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim();
+		expenseListController=new ExpenseListController(expenseList);
 		
 		listener=new Listener() {			
 			@Override
@@ -65,7 +71,6 @@ public class EditExpenseActivity extends Activity {
 	}
 
 	private void updateValues(){
-		Expense expense = ExpenseListController.getCurrentExpense();
 		Spinner categorySpinner = (Spinner) this.findViewById(R.id.categorySelector);	
 		for (int i = 0; i < categorySpinner.getAdapter().getCount();++i){
 			if (String.valueOf(categorySpinner.getItemAtPosition(i)).equals(expense.getCategory())){
@@ -93,8 +98,8 @@ public class EditExpenseActivity extends Activity {
 			}
 		}
 		
-		if (ClaimListController.getCurrentClaim().status == Claim.Status.submitted || 
-				ClaimListController.getCurrentClaim().status == Claim.Status.approved){
+		if (claim.status == Claim.Status.submitted || 
+				claim.status == Claim.Status.approved){
 			//Disable UI if the claim is not editable
 			descriptionView.setEnabled(false);
 			dateView.setEnabled(false);
@@ -106,7 +111,7 @@ public class EditExpenseActivity extends Activity {
 		
 		
 		//TEMPORARY code to show the photo in the image button
-		Log.d("Testing Add Photo", "File for updating? " + (ExpenseListController.getCurrentExpense().getReceipt() != null));
+		Log.d("Testing Add Photo", "File for updating? " + (expense.getReceipt() != null));
 		if (expense.receipt != null){			
 			thumbnailReceipt(BitmapFactory.decodeFile(expense.getReceipt().getAbsolutePath()));
 			Log.d("Testing Add Photo", "Update thumbed");
@@ -125,7 +130,7 @@ public class EditExpenseActivity extends Activity {
 	public void onExpenseSaveClick(View v) {
 
 		//editing model happens in controller 
-		ExpenseListController.onExpenseSaveClick(this);
+		expenseListController.onExpenseSaveClick(this);
 	}
 		
 	@Override
@@ -175,15 +180,15 @@ public class EditExpenseActivity extends Activity {
 	Log.d("Testing Add Photo", "Creating File");
 	File photoFile = new  File(this.getFilesDir().getAbsolutePath() + 
 			"/" + filePath);
-	ExpenseListController.getCurrentExpense().setReceipt(photoFile);
-	Log.d("Testing Add Photo", "File Added to Expense? " + (ExpenseListController.getCurrentExpense().getReceipt() != null));
+	expense.setReceipt(photoFile);
+	Log.d("Testing Add Photo", "File Added to Expense? " + (expense.getReceipt() != null));
 	}
 	
 	public void onDeletePhotoClick(View v){
-		if(ExpenseListController.getCurrentExpense().getReceipt() != null){
-			ExpenseListController.getCurrentExpense().getReceipt().delete();
+		if(expense.getReceipt() != null){
+			expense.getReceipt().delete();
 			thumbnailReceipt(null);
-			ExpenseListController.getCurrentExpense().setReceipt(null);
+			expense.setReceipt(null);
 		}
 	}
 	

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/EditExpenseActivity.java
@@ -59,6 +59,7 @@ public class EditExpenseActivity extends Activity {
 		expenseList = claim.getExpenseList();
 		expense=SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense();
 		expenseListController=new ExpenseListController(expenseList);
+		expenseListController.setCurrentExpense(expense);
 		
 		listener=new Listener() {			
 			@Override

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseList.java
@@ -23,7 +23,7 @@ import java.util.ArrayList;
 public class ExpenseList {
 
 	private ArrayList<Expense> expenseList;
-	private ArrayList<Listener> listeners;
+	private transient ArrayList<Listener> listeners;
 	
 	/**
 	 * Create a new empty ExpenseList
@@ -58,6 +58,8 @@ public class ExpenseList {
 		for(int i=0; i<listeners.size();i++){
 			listeners.get(i).update();
 		}
+		//added for now so claimslist is saved whenever expenselist is modified, probably suboptimal
+		UserSingleton.getUserSingleton().getUser().getClaimList().saveClaims();
 	}
 
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
@@ -34,10 +34,31 @@ import android.widget.Spinner;
  */
 public class ExpenseListController {
 	protected ExpenseList expenseList;
+	protected Expense currentExpense;
 	
 	
 	public ExpenseListController(ExpenseList expenseList) {
 		this.expenseList=expenseList;
+	}
+	
+	
+	/**
+	 * Sets the current Expense item that is to be controlled.
+	 * @param expense
+	 * An Expense.
+	 */
+	public void setCurrentExpense(Expense expense){
+		currentExpense = expense; 
+	}
+	
+	
+	/**
+	 * Returns the current Expense item that is being controlled.
+	 * @return
+	 * An Expense.
+	 */
+	public Expense getCurrentExpense(){
+		return currentExpense;
 	}
 	
 	
@@ -58,6 +79,7 @@ public class ExpenseListController {
 	public void addExpense(Expense expense){
 		ArrayList<Expense> expenseArray=expenseList.getExpenses();
 		expenseArray.add(expense);
+		setCurrentExpense(expense);
 		///setCurrentExpenseList(ClaimListController.getCurrentClaim().getExpenseList());
 		//display empty expense then show activity to edit empty claim otherwise an empty expense will not show after hitting back
 		expenseList.setExpenseList(expenseArray);
@@ -90,7 +112,7 @@ public class ExpenseListController {
 			}
 			ArrayList<Expense> expenseArray=expenseList.getExpenses();
 			expenseArray.set(expenseArray.indexOf(expense), newExpense);
-			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(newExpense);
+			setCurrentExpense(newExpense);
 			expenseList.setExpenseList(expenseArray);
 		}
 	}
@@ -127,9 +149,9 @@ public class ExpenseListController {
 		if ( completeBox.isChecked() ) {
 			expense.setFlagged(true);
 		}
-		expense.setReceipt(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense().getReceipt());
+		expense.setReceipt(getCurrentExpense().getReceipt());
 		
-		updateExpense(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense(), expense);
+		updateExpense(getCurrentExpense(), expense);
 		
 		activity.finish();	
 	}
@@ -152,7 +174,7 @@ public class ExpenseListController {
 	 * Simply removes the expense that was selected. 
 	 */
 	public void onRemoveExpenseClick() {
-		removeExpense(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense());
+		removeExpense(getCurrentExpense());
 	}
 	
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
@@ -33,33 +33,21 @@ import android.widget.Spinner;
  * Controller for all ExpenseLists, The contained ExpenseList will be automatically linked when expenses are being accessed.
  */
 public class ExpenseListController {
-	protected static Expense currentExpense = null;
+	protected ExpenseList expenseList;
+	
+	
+	public ExpenseListController(ExpenseList expenseList) {
+		this.expenseList=expenseList;
+	}
+	
 	
 	/**
 	 * Returns the ExpenseList for the claim that is currently being accessed.
 	 * @return
 	 * The ExpenseList for the active claim.
 	 */
-	public static ExpenseList getCurrentExpenseList() { 
-		return ClaimListController.getCurrentClaim().getExpenseList();
-	}
-	
-	/**
-	 * Sets the current Expense item that is to be controlled.
-	 * @param expense
-	 * An Expense.
-	 */
-	public static void setCurrentExpense(Expense expense){
-		currentExpense = expense; 
-	}
-	
-	/**
-	 * Returns the current Expense item that is being controlled.
-	 * @return
-	 * An Expense.
-	 */
-	public static Expense getCurrentExpense(){
-		return currentExpense;
+	public ExpenseList getExpenseList() { 
+		return expenseList;
 	}
 
 	/**
@@ -67,13 +55,12 @@ public class ExpenseListController {
 	 * @param expense
 	 * An Expense.
 	 */
-	public static void addExpense(Expense expense){
-		ArrayList<Expense> expenseArray=ExpenseListController.getCurrentExpenseList().getExpenses();
+	public void addExpense(Expense expense){
+		ArrayList<Expense> expenseArray=expenseList.getExpenses();
 		expenseArray.add(expense);
-		setCurrentExpense(expense);
 		///setCurrentExpenseList(ClaimListController.getCurrentClaim().getExpenseList());
 		//display empty expense then show activity to edit empty claim otherwise an empty expense will not show after hitting back
-		getCurrentExpenseList().setExpenseList(expenseArray);
+		expenseList.setExpenseList(expenseArray);
 	}
 	
 	/**
@@ -81,10 +68,10 @@ public class ExpenseListController {
 	 * @param expense
 	 * An Expense.
 	 */
-	public static void removeExpense(Expense expense){
-		ArrayList<Expense> expenseArray=ExpenseListController.getCurrentExpenseList().getExpenses();
+	public void removeExpense(Expense expense){
+		ArrayList<Expense> expenseArray=expenseList.getExpenses();
 		expenseArray.remove(expense);
-		getCurrentExpenseList().setExpenseList(expenseArray);
+		expenseList.setExpenseList(expenseArray);
 	}
 	
 	/**
@@ -94,17 +81,17 @@ public class ExpenseListController {
 	 * @param newExpense
 	 * The new Expense.
 	 */
-	public static void updateExpense(Expense expense, Expense newExpense){
-		if (ClaimListController.getCurrentClaim().status != Claim.Status.submitted && 
-				ClaimListController.getCurrentClaim().status != Claim.Status.approved){
+	public void updateExpense(Expense expense, Expense newExpense){
+		if (SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().status != Claim.Status.submitted && 
+				SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentClaim().status != Claim.Status.approved){
 			
 			if(newExpense.getAmount().floatValue() == 0){
 				newExpense.setCurrency("");
 			}
-			ArrayList<Expense> expenseArray=ExpenseListController.getCurrentExpenseList().getExpenses();
+			ArrayList<Expense> expenseArray=expenseList.getExpenses();
 			expenseArray.set(expenseArray.indexOf(expense), newExpense);
-			setCurrentExpense(newExpense);
-			getCurrentExpenseList().setExpenseList(expenseArray);
+			SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(newExpense);
+			expenseList.setExpenseList(expenseArray);
 		}
 	}
 	
@@ -114,7 +101,7 @@ public class ExpenseListController {
 	 * @param activity
 	 * The EditExpenseActivity which contains the needed layouts.
 	 */
-	public static void onExpenseSaveClick(EditExpenseActivity activity) {
+	public void onExpenseSaveClick(EditExpenseActivity activity) {
 			
 		Spinner categorySpinner = (Spinner) activity.findViewById(R.id.categorySelector);
 		String categoryText = String.valueOf(categorySpinner.getSelectedItem());
@@ -140,9 +127,9 @@ public class ExpenseListController {
 		if ( completeBox.isChecked() ) {
 			expense.setFlagged(true);
 		}
-		expense.setReceipt(ExpenseListController.getCurrentExpense().getReceipt());
+		expense.setReceipt(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense().getReceipt());
 		
-		updateExpense(getCurrentExpense(), expense);
+		updateExpense(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense(), expense);
 		
 		activity.finish();	
 	}
@@ -153,8 +140,8 @@ public class ExpenseListController {
 	 * @param activity
 	 * The ClaimantExpenseListActivity which contains the needed layout.
 	 */
-	public static void onAddExpenseClick(ClaimantExpenseListActivity activity) {
-		ExpenseListController.addExpense(new Expense());
+	public void onAddExpenseClick(ClaimantExpenseListActivity activity) {
+		addExpense(new Expense());
 		Intent intent = new Intent(activity, EditExpenseActivity.class);
 		activity.startActivity(intent);
 		
@@ -164,8 +151,8 @@ public class ExpenseListController {
 	 * Called from the dialog in the ClaimantExpenseListActivity.
 	 * Simply removes the expense that was selected. 
 	 */
-	public static void onRemoveExpenseClick() {
-		removeExpense(currentExpense);
+	public void onRemoveExpenseClick() {
+		removeExpense(SelectedItemsSingleton.getSelectedItemsSingleton().getCurrentExpense());
 	}
 	
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
@@ -164,6 +164,7 @@ public class ExpenseListController {
 	 */
 	public void onAddExpenseClick(ClaimantExpenseListActivity activity) {
 		addExpense(new Expense());
+		SelectedItemsSingleton.getSelectedItemsSingleton().setCurrentExpense(currentExpense);
 		Intent intent = new Intent(activity, EditExpenseActivity.class);
 		activity.startActivity(intent);
 		

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/ExpenseListController.java
@@ -153,6 +153,7 @@ public class ExpenseListController {
 		
 		updateExpense(getCurrentExpense(), expense);
 		
+		
 		activity.finish();	
 	}
 	

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
@@ -65,12 +65,11 @@ public class LoginActivity extends Activity {
 		EditText userNameField = (EditText) findViewById(R.id.userNameField);
 		String currentUserName=userNameField.getText().toString();
 		if(currentUserName.equals("")) currentUserName="Guest";
-		User currentUser=new User("Approver", currentUserName);
-		ClaimListController.setUser(currentUser);
-		TagListController.getTagList().getManager().setContext(getApplicationContext());
-		TagListController.getTagList().loadTags();
-		ClaimListController.getClaimList().getManager().setContext(getApplicationContext());
-		ClaimListController.getClaimList().loadClaims();
+		Approver currentUser=new Approver(currentUserName);
+		UserSingleton.getUserSingleton().setUser(currentUser);
+		ClaimList claimList=currentUser.getClaimList();
+		claimList.getManager().setContext(getApplicationContext());
+		claimList.loadClaims();
 		startActivity(intent);
 	}
 	
@@ -78,17 +77,17 @@ public class LoginActivity extends Activity {
 	 * Start the ClaimantClaimsListActivity if the user chooses to log in as an claimant.
 	 * @param v the button clicked by the user.
 	 */
-	public void userLogin(View v){
+	public void claimantLogin(View v){
 		Intent intent = new Intent(LoginActivity.this,ClaimantClaimsListActivity.class);
 		EditText userNameField = (EditText) findViewById(R.id.userNameField);
 		String currentUserName=userNameField.getText().toString();
 		if(currentUserName.equals("")) currentUserName="Guest";
-		User currentUser=new User("Claimant", currentUserName);
-		ClaimListController.setUser(currentUser);
-		TagListController.getTagList().getManager().setContext(getApplicationContext());
-		TagListController.getTagList().loadTags();
-		ClaimListController.getClaimList().getManager().setContext(getApplicationContext());
-		ClaimListController.getClaimList().loadClaims();
+		Claimant currentUser=new Claimant(currentUserName);
+		UserSingleton.getUserSingleton().setUser(currentUser);
+		currentUser.getTagList().getManager().setContext(getApplicationContext());
+		currentUser.getTagList().loadTags();
+		currentUser.getClaimList().getManager().setContext(getApplicationContext());
+		currentUser.getClaimList().loadClaims();
 		startActivity(intent);
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
@@ -69,6 +69,10 @@ public class LoginActivity extends Activity {
 		UserSingleton.getUserSingleton().setUser(currentUser);
 		ClaimList claimList=currentUser.getClaimList();
 		claimList.getManager().setContext(getApplicationContext());
+		ClaimListManager claimListManager=currentUser.getClaimList().getManager();
+		claimListManager.setContext(getApplicationContext());
+		//temporary savefile name for testing approver side without online funcitonality
+		claimListManager.setSaveFile("Guest_claims.sav");
 		claimList.loadClaims();
 		startActivity(intent);
 	}
@@ -82,16 +86,24 @@ public class LoginActivity extends Activity {
 		EditText userNameField = (EditText) findViewById(R.id.userNameField);
 		String currentUserName=userNameField.getText().toString();
 		if(currentUserName.equals("")) currentUserName="Guest";
+		
+		
 		Claimant currentUser=new Claimant(currentUserName);
 		UserSingleton.getUserSingleton().setUser(currentUser);
+		
+		
 		TagListManager tagListManager=currentUser.getTagList().getManager();
 		tagListManager.setContext(getApplicationContext());
 		tagListManager.setSaveFile(currentUserName+"_tags.sav");
 		currentUser.getTagList().loadTags();
+		
+		
 		ClaimListManager claimListManager=currentUser.getClaimList().getManager();
 		claimListManager.setContext(getApplicationContext());
 		claimListManager.setSaveFile(currentUserName+"_claims.sav");
 		currentUser.getClaimList().loadClaims();
+		
+		
 		startActivity(intent);
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/LoginActivity.java
@@ -84,9 +84,13 @@ public class LoginActivity extends Activity {
 		if(currentUserName.equals("")) currentUserName="Guest";
 		Claimant currentUser=new Claimant(currentUserName);
 		UserSingleton.getUserSingleton().setUser(currentUser);
-		currentUser.getTagList().getManager().setContext(getApplicationContext());
+		TagListManager tagListManager=currentUser.getTagList().getManager();
+		tagListManager.setContext(getApplicationContext());
+		tagListManager.setSaveFile(currentUserName+"_tags.sav");
 		currentUser.getTagList().loadTags();
-		currentUser.getClaimList().getManager().setContext(getApplicationContext());
+		ClaimListManager claimListManager=currentUser.getClaimList().getManager();
+		claimListManager.setContext(getApplicationContext());
+		claimListManager.setSaveFile(currentUserName+"_claims.sav");
 		currentUser.getClaimList().loadClaims();
 		startActivity(intent);
 	}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/SelectedItemsSingleton.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/SelectedItemsSingleton.java
@@ -1,0 +1,36 @@
+package ca.ualberta.cs.team1travelexpenseapp;
+
+public class SelectedItemsSingleton {
+	private static SelectedItemsSingleton selectedItemsSingleton=null;
+	private Claim currentClaim;
+	private Expense currentExpense;
+	
+	private SelectedItemsSingleton(){
+		
+	}
+	
+	public static SelectedItemsSingleton getSelectedItemsSingleton(){
+		if(selectedItemsSingleton==null){
+			selectedItemsSingleton=new SelectedItemsSingleton();
+		}
+		return selectedItemsSingleton;
+	}
+	
+	public Claim getCurrentClaim() {
+		return currentClaim;
+	}
+
+	public void setCurrentClaim(Claim currentClaim) {
+		this.currentClaim = currentClaim;
+	}
+	
+	public Expense getCurrentExpense() {
+		return currentExpense;
+	}
+
+	public void setCurrentExpense(Expense currentExpense) {
+		this.currentExpense = currentExpense;
+	}
+
+	
+}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
@@ -28,7 +28,7 @@ public class TagList {
 	private static TagListManager manager;
 	
 	TagList(){
-		manager=new TagListManager(this);
+		manager=new TagListManager(this,UserSingleton.getUserSingleton().getUser().getName());
 		tagList=new ArrayList<Tag>();
 		listeners=new ArrayList<Listener>();
 	}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
@@ -28,7 +28,7 @@ public class TagList {
 	private static TagListManager manager;
 	
 	TagList(){
-		manager=new TagListManager(this,UserSingleton.getUserSingleton().getUser().getName());
+		manager=new TagListManager(this);
 		tagList=new ArrayList<Tag>();
 		listeners=new ArrayList<Listener>();
 	}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagList.java
@@ -24,7 +24,7 @@ import android.content.Context;
  */
 public class TagList {
 	private ArrayList<Tag> tagList;
-	private ArrayList<Listener> listeners;
+	private transient ArrayList<Listener> listeners;
 	private static TagListManager manager;
 	
 	TagList(){

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListController.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListController.java
@@ -25,26 +25,22 @@ import android.widget.EditText;
  * Provides a set of methods which allow the TagListManagerActivity view to modify the underlying TagList data.
  */
 public class TagListController {
-	private static TagList tagList=null;
+	private TagList tagList;
 
 	/**
 	 * Return the controlled TagList, will be created on the first call.
 	 * @return The controlled TagList
 	 */
-	public static TagList getTagList() { 
-		if (tagList == null) {
-			tagList = new TagList();
-		}
-		
-		return tagList;
+	TagListController(TagList tagList){
+		this.tagList=tagList;
 	}
 	
 	/**
 	 * Add a Tag to the TagList.
 	 * @param tag The Tag to be added
 	 */
-	public static void addTag(Tag tag){
-		ArrayList<Tag> tagArray=TagListController.getTagList().getTags();
+	public void addTag(Tag tag){
+		ArrayList<Tag> tagArray=tagList.getTags();
 		tagArray.add(tag);
 		tagList.setTagList(tagArray);
 	}
@@ -53,8 +49,8 @@ public class TagListController {
 	 * Remove the passed tag from the TagList.
 	 * @param tag The Tag to be removed
 	 */
-	public static void removeTag(Tag tag){
-		ArrayList<Tag> tagArray=TagListController.getTagList().getTags();
+	public void removeTag(Tag tag){
+		ArrayList<Tag> tagArray=tagList.getTags();
 		tagArray.remove(tag);
 		tagList.setTagList(tagArray);
 	}
@@ -64,8 +60,8 @@ public class TagListController {
 	 * @param tag The Tag to be modified
 	 * @param newName A String to be used as the new name for tag
 	 */
-	public static void updateTag(Tag tag, String newName){
-		ArrayList<Tag> tagArray=TagListController.getTagList().getTags();
+	public void updateTag(Tag tag, String newName){
+		ArrayList<Tag> tagArray=tagList.getTags();
 		tagArray.set(tagArray.indexOf(tag), new Tag(newName));
 		tagList.setTagList(tagArray);
 	}
@@ -75,14 +71,14 @@ public class TagListController {
 	 * Grabs the string entered by the user and creates a new tag by that name in the TagList.
 	 * @param dialog The Dialog in which the add tag button resides
 	 */
-    public static boolean onAddTagClick(DialogInterface dialog) {
+    public boolean onAddTagClick(DialogInterface dialog) {
         EditText nameField=((EditText) ((AlertDialog) dialog).findViewById(R.id.simpleEditText));
         String name=nameField.getText().toString();
-        if(getTagList().hasTagNamed(name)){
+        if(tagList.hasTagNamed(name)){
         	return false;
         }
         else{
-        TagListController.addTag(new Tag(name));
+        addTag(new Tag(name));
         return true;
         }
     }
@@ -93,14 +89,14 @@ public class TagListController {
      * @param dialog The Dialog in which the set tag button resides
      * @param tag The Tag to be modified
      */
-    public static boolean onSetTagClick(DialogInterface dialog, Tag tag) {
+    public boolean onSetTagClick(DialogInterface dialog, Tag tag) {
  	   	EditText nameField=((EditText) ((AlertDialog) dialog).findViewById(R.id.simpleEditText));
         String name=nameField.getText().toString();
-        if(getTagList().hasTagNamed(name)){
+        if(tagList.hasTagNamed(name)){
         	return false;
         }
         else{
-        TagListController.updateTag(tag, name);
+        updateTag(tag, name);
         return true;
         }
     }
@@ -111,14 +107,14 @@ public class TagListController {
      * @param dialog The Dialog in which remove tag button resides
      * @param tag A Tag to be removed
      */
-    public static void onRemoveTagClick(DialogInterface dialog, Tag tag) {
-    	TagListController.removeTag(tag);
+    public void onRemoveTagClick(DialogInterface dialog, Tag tag) {
+    	removeTag(tag);
     }
     
     /**
      * Reset the TagList to a new TagList removing all it's old contents.
      */
-    public static void clearTagList(){
+    public void clearTagList(){
     	tagList=new TagList();
     }
     

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListManager.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListManager.java
@@ -36,13 +36,15 @@ import android.content.Context;
 public class TagListManager {
 	private TagList tagList;
 	private Context context;
+	private String userName;
 	
 	/**
 	 * Initialize with the tagList to be managed.
 	 * @param tagList The TagList to saved from and loaded to
 	 */
-	TagListManager(TagList tagList){
+	TagListManager(TagList tagList, String userName){
 		this.tagList=tagList;
+		this.userName=userName;
 	}
 	
 	/**
@@ -50,7 +52,7 @@ public class TagListManager {
 	 */
 	public void saveTags(){
 		Gson gson = new Gson();
-		String saveFile=ClaimListController.getUser().getName()+"_tags.sav";
+		String saveFile=userName+"_tags.sav";
 		try {
 			FileOutputStream fos = context.openFileOutput(saveFile, 0);
 			OutputStreamWriter osw = new OutputStreamWriter(fos);
@@ -73,7 +75,7 @@ public class TagListManager {
 	public void loadTags(){
 		Gson gson = new Gson();
 		ArrayList<Tag> tags=new ArrayList <Tag>();
-		String saveFile=ClaimListController.getUser().getName()+"_tags.sav";
+		String saveFile=userName+"_tags.sav";
 		try {
 			FileInputStream fis = context.openFileInput(saveFile);
 			InputStreamReader in =new InputStreamReader(fis);

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListManager.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagListManager.java
@@ -36,23 +36,26 @@ import android.content.Context;
 public class TagListManager {
 	private TagList tagList;
 	private Context context;
-	private String userName;
+	private String saveFile;
 	
 	/**
 	 * Initialize with the tagList to be managed.
 	 * @param tagList The TagList to saved from and loaded to
 	 */
-	TagListManager(TagList tagList, String userName){
+	TagListManager(TagList tagList){
 		this.tagList=tagList;
-		this.userName=userName;
+		this.saveFile="tags.sav";
 	}
-	
+
+	public void setSaveFile(String savefile) {
+		this.saveFile = savefile;
+	}
+
 	/**
 	 * save Tags to disk (and if possible to web server). (not yet implemented)
 	 */
 	public void saveTags(){
 		Gson gson = new Gson();
-		String saveFile=userName+"_tags.sav";
 		try {
 			FileOutputStream fos = context.openFileOutput(saveFile, 0);
 			OutputStreamWriter osw = new OutputStreamWriter(fos);
@@ -75,7 +78,6 @@ public class TagListManager {
 	public void loadTags(){
 		Gson gson = new Gson();
 		ArrayList<Tag> tags=new ArrayList <Tag>();
-		String saveFile=userName+"_tags.sav";
 		try {
 			FileInputStream fis = context.openFileInput(saveFile);
 			InputStreamReader in =new InputStreamReader(fis);

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagManagerActivity.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/TagManagerActivity.java
@@ -40,6 +40,7 @@ import android.widget.Toast;
  */
 public class TagManagerActivity extends Activity {
 	private TagList tagList;
+	private TagListController tagListController;
 	public AlertDialog newTagDialog;
 	public AlertDialog editTagDialog;
 	private Listener listener;
@@ -55,9 +56,12 @@ public class TagManagerActivity extends Activity {
 		super.onCreate(savedInstanceState);
 		setContentView(R.layout.activity_manage_tags);
 		
+		
+		tagList=((Claimant)UserSingleton.getUserSingleton().getUser()).getTagList();
+		tagListController=new TagListController(tagList);
+		
 		//taken from https://github.com/abramhindle/student-picker and modified
 		final ListView tagsListView = (ListView) findViewById(R.id.tagsList);
-		tagList=TagListController.getTagList();
 		Collection<Tag> tags = tagList.getTags();
 		final ArrayList<Tag> tagsList = new ArrayList<Tag>(tags);
 		final ArrayAdapter<Tag> tagsAdapter = new ArrayAdapter<Tag>(this, android.R.layout.simple_list_item_1, tagsList);
@@ -67,7 +71,7 @@ public class TagManagerActivity extends Activity {
 			@Override
 			public void update() {
 				tagsList.clear();
-				Collection<Tag> tags = TagListController.getTagList().getTags();
+				Collection<Tag> tags = tagList.getTags();
 				tagsList.addAll(tags);
 				tagsAdapter.notifyDataSetChanged();
 			}
@@ -87,7 +91,7 @@ public class TagManagerActivity extends Activity {
 						 editTagDialogBuilder.setView(getLayoutInflater().inflate(R.layout.simple_edit_text, null));
 						 editTagDialogBuilder.setPositiveButton("save", new DialogInterface.OnClickListener() {
 					           public void onClick(DialogInterface dialog, int id) {
-					        	   boolean tagChanged=TagListController.onSetTagClick(dialog, tag);
+					        	   boolean tagChanged=tagListController.onSetTagClick(dialog, tag);
 					        	   if(!tagChanged){
 					            	   Toast.makeText(getApplicationContext(),"Sorry a tag by that "
 					            	   		+ "name exists (not modified)",Toast.LENGTH_LONG).show();
@@ -96,7 +100,7 @@ public class TagManagerActivity extends Activity {
 					       });
 						editTagDialogBuilder.setNegativeButton("delete", new DialogInterface.OnClickListener() {
 					           public void onClick(DialogInterface dialog, int id) {
-					        	   TagListController.onRemoveTagClick(dialog, tag);
+					        	   tagListController.onRemoveTagClick(dialog, tag);
 					           }
 					       });
 						editTagDialogBuilder.setNeutralButton("cancel", new DialogInterface.OnClickListener() {
@@ -120,7 +124,7 @@ public class TagManagerActivity extends Activity {
 		
 		newTagDialogBuilder.setPositiveButton("save", new DialogInterface.OnClickListener() {
 	           public void onClick(DialogInterface dialog, int id) {
-	               boolean tagAdded=TagListController.onAddTagClick(dialog);
+	               boolean tagAdded=tagListController.onAddTagClick(dialog);
 	               if(!tagAdded){
 	            	   Toast.makeText(getApplicationContext(),"Sorry a tag by that name exists (not added)",
 	            			   Toast.LENGTH_LONG).show();

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
@@ -20,6 +20,15 @@ public class User {
 	
 	private String name;
 	private Claim currentClaim;
+	protected ClaimList claimList;
+
+	public ClaimList getClaimList() {
+		return claimList;
+	}
+
+	public void setClaimList(ClaimList claimList) {
+		this.claimList = claimList;
+	}
 
 	public Claim getCurrentClaim() {
 		return currentClaim;
@@ -37,6 +46,7 @@ public class User {
 	public User(String name) {
 		// TODO Auto-generated constructor stub
 		this.name = name;
+		this.claimList=new ClaimList();
 	}
 
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
@@ -18,7 +18,16 @@ package ca.ualberta.cs.team1travelexpenseapp;
  */
 public class User {
 	
-	private String name = null;
+	private String name;
+	private Claim currentClaim;
+
+	public Claim getCurrentClaim() {
+		return currentClaim;
+	}
+
+	public void setCurrentClaim(Claim currentClaim) {
+		this.currentClaim = currentClaim;
+	}
 
 	/**
 	 * Create the user with a passed name and type

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
@@ -18,8 +18,7 @@ package ca.ualberta.cs.team1travelexpenseapp;
  */
 public class User {
 	
-	private String name;
-	private Claim currentClaim;
+	protected String name;
 	protected ClaimList claimList;
 
 	public ClaimList getClaimList() {
@@ -28,14 +27,6 @@ public class User {
 
 	public void setClaimList(ClaimList claimList) {
 		this.claimList = claimList;
-	}
-
-	public Claim getCurrentClaim() {
-		return currentClaim;
-	}
-
-	public void setCurrentClaim(Claim currentClaim) {
-		this.currentClaim = currentClaim;
 	}
 
 	/**

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/User.java
@@ -18,7 +18,6 @@ package ca.ualberta.cs.team1travelexpenseapp;
  */
 public class User {
 	
-	protected String type = null;
 	private String name = null;
 
 	/**
@@ -26,30 +25,11 @@ public class User {
 	 * @param type A String representing type of the user (claimant or approver)
 	 * @param name A String representing the name of the user
 	 */
-	public User(String type, String name) {
+	public User(String name) {
 		// TODO Auto-generated constructor stub
-		
-		this.type = type;
 		this.name = name;
 	}
 
-	/**
-	 * Return the current type of the user
-	 * @return The current type of the user (claimant or approver)
-	 */
-	public String type() {
-		// TODO Auto-generated method stub
-		return type;
-	}
-
-	/**
-	 * Will eventually return whether the user in question has logged in to the app (not yet implemented)
-	 * @return boolean indicating whether the user is logged into the app
-	 */
-	public static boolean loggedin() {
-		// TODO Auto-generated method stub
-		return true;
-	}
 	/**
 	 * Return the name of the User
 	 * @return name of the current User

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/UserSingleton.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/UserSingleton.java
@@ -1,0 +1,25 @@
+package ca.ualberta.cs.team1travelexpenseapp;
+
+public class UserSingleton {
+	private static UserSingleton userSingleton=null;
+	private User user;
+	
+	private UserSingleton(){
+		
+	}
+	
+	public static UserSingleton getUserSingleton(){
+		if(userSingleton==null){
+			userSingleton=new UserSingleton();
+		}
+		return userSingleton;
+	}
+	
+	public User getUser(){
+		return this.user;
+	}
+	
+	public void setUser(User user){
+		this.user=user;
+	}
+}

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/adapter/SubmittedClaimAdapter.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/adapter/SubmittedClaimAdapter.java
@@ -16,6 +16,8 @@ import ca.ualberta.cs.team1travelexpenseapp.Expense;
 import ca.ualberta.cs.team1travelexpenseapp.ExpenseList;
 import ca.ualberta.cs.team1travelexpenseapp.Tag;
 import ca.ualberta.cs.team1travelexpenseapp.User;
+import ca.ualberta.cs.team1travelexpenseapp.Claimant;
+import ca.ualberta.cs.team1travelexpenseapp.UserSingleton;
 import ca.ualberta.cs.team1travelexpenseapp.claims.AbstractClaim;
 import ca.ualberta.cs.team1travelexpenseapp.claims.ProgressClaim;
 import ca.ualberta.cs.team1travelexpenseapp.claims.SubmittedClaim;
@@ -230,7 +232,7 @@ public class SubmittedClaimAdapter extends SubmittedClaim{
 	 */
 	@Override
 	public int compareTo( AbstractClaim claim ) {
-		if (ClaimListController.getUserType().equals("Claimant")) {
+		if (UserSingleton.getUserSingleton().getUser().getClass().equals(Claimant.class)) {
 			return claim.getStartDate().compareTo(this.startDate);
 		}
 		return this.startDate.compareTo(claim.getStartDate());

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/claims/AbstractClaim.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/claims/AbstractClaim.java
@@ -279,9 +279,6 @@ public abstract class AbstractClaim implements Comparable<AbstractClaim> {
 	 */
 	@Override
 	public int compareTo( AbstractClaim claim ) {
-		if (ClaimListController.getUserType().equals("Claimant")) {
-			return claim.startDate.compareTo(this.startDate);
-		}
 		return this.startDate.compareTo(claim.startDate);
 	}
 }

--- a/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/claims/SubmittedClaim.java
+++ b/Team1TravelExpenseApp/src/ca/ualberta/cs/team1travelexpenseapp/claims/SubmittedClaim.java
@@ -5,6 +5,7 @@ import java.util.Date;
 
 import ca.ualberta.cs.team1travelexpenseapp.ClaimListController;
 import ca.ualberta.cs.team1travelexpenseapp.User;
+import ca.ualberta.cs.team1travelexpenseapp.UserSingleton;
 
 public class SubmittedClaim extends AbstractClaim {
 
@@ -31,7 +32,7 @@ public class SubmittedClaim extends AbstractClaim {
 	 * @param comment String to be added as comment.
 	 */
 	public void addComment(String comment) {
-		commentList.put(ClaimListController.getUser().getName(), comment);
+		commentList.put(UserSingleton.getUserSingleton().getUser().getName(), comment);
 	}
 
 }


### PR DESCRIPTION
Everything seems to be working again, I may have removed some things that should be put back in if they didn't seem immediately necessary and relied on the previous singletons. Instead of the singleton controllers there are now two new singletons:

UserSingleton: stores the currently logged in user.

SelectedItemSingleton: stores the currently selected Claim and Expense, should only be used to pass this information between activities.

The user now has an associated claimList in addition to a name. There are now two subclasses of user, Claimant and Approver so we can give them different behaviour as necessary.

All the tests are now broken, but this should be superficial because they rely on the old singletons in their setup, hopefully they are easy to fix.

When logging in as approver the loaded claimList now correspond to those of the "Guest" user which is the default if you don't type anything in the name bar when logging on. This behavior is temporary so there is a reasonable way to test the approver side of things. When I implement the online stuff the approvers list will be pulled from the submitted claims on the server.